### PR TITLE
Enable node retrieval without type

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -102,8 +102,17 @@ function nodeFactory(config = {}) {
      */
     function get(types) {
       if (id === undefined) throw new Error('Node is undefined');
-      if (type === undefined && types === undefined)
-        throw new Error('Type is undefined');
+      if (type === undefined && types === undefined){
+        return documentClient
+              .query({
+                TableName: table,
+                KeyConditionExpression: 'Node = :Node',
+                FilterExpression: 'attribute_exists(Target) AND Target = :Node',
+                ExpressionAttributeValues: {':Node': pTenant(id)}
+              })
+              .promise()
+              .then(({Items}) => Items.length && parseItem(Items[0]));
+      }
 
       if (type !== undefined && Array.isArray(types) === true)
         types = [type].concat(types);


### PR DESCRIPTION
From what I can tell, there are 3 types of entities.

`Node/Vertex`: Has `Target` property that `===` `Node`
`Edge`: Has `Target` property that `!==` `Node`
`Param`: Has no `Target` property

Given, this... We can find a `Node/Vertex` using only the `Node` property and ensuring that `Target === Node`